### PR TITLE
ansible.cfg: Update yaml format option

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 inventory = hosts.cfg
-stdout_callback = yaml
+callback_result_format = yaml
 nocows = True
 
 [ssh_connection]


### PR DESCRIPTION
This fixes the following warning:

[DEPRECATION WARNING]: community.general.yaml has been deprecated. The plugin has been superseded by the the option `result_format=yaml` in callback plugin ansible.builtin.default from ansible-core 2.13 onwards. This feature will be removed from community.general in version 12.0.0. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.