### PR TITLE
Tweak sshd configuration

### DIFF
--- a/ansible/files/sshd-local.conf
+++ b/ansible/files/sshd-local.conf
@@ -1,0 +1,6 @@
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+X11Forwarding no
+# Enable "post-quantum" key exchange algorithms to suppress a warning
+# from the OpenSSH 10.1 client
+KexAlgorithms +mlkem768x25519-sha256,sntrup761x25519-sha512

--- a/ansible/playbook-setup-kiwi3.yml
+++ b/ansible/playbook-setup-kiwi3.yml
@@ -197,6 +197,13 @@
       group: root
       mode: 0644
 
+  - name: Configure sshd
+    blockinfile:
+      path: /etc/ssh/sshd_config
+      block: "{{ lookup('file', 'files/sshd-local.conf') }}"
+      insertbefore: BOF
+      append_newline: true
+
   - name: Configure fail2ban
     copy:
       src: "{{ item.src }}"

--- a/ansible/playbook-setup-quince.yml
+++ b/ansible/playbook-setup-quince.yml
@@ -107,6 +107,13 @@
       group: root
       mode: 0644
 
+  - name: Configure sshd
+    blockinfile:
+      path: /etc/ssh/sshd_config
+      block: "{{ lookup('file', 'files/sshd-local.conf') }}"
+      insertbefore: BOF
+      append_newline: true
+
   - name: Configure fail2ban
     copy:
       src: "{{ item.src }}"


### PR DESCRIPTION
- Disable password and keyboard-interactive authentication
- Disable X11 forwarding
- Enable "post-quantum" key exchange algorithms to suppress a warning from the OpenSSH 10.1 client