### PR TITLE
Update docker_prune

### DIFF
--- a/ansible/playbook-setup-kiwi3.yml
+++ b/ansible/playbook-setup-kiwi3.yml
@@ -288,5 +288,9 @@
   - name: Prune Docker containers and images
     community.docker.docker_prune:
       containers: true
+      containers_filters:
+        # Keep containers for 60 days so we don't lose the logs
+        # Unfortunately, "until" uses creation time, not stop time
+        until: 1440h
       images: true
       volumes: true


### PR DESCRIPTION
I noticed that we lose all http logs when pruning the old docker containers. This should remedy it somewhat, by adding containers_filters to the docker_prune configurarion.

Notes:
- `until` counts since container creation, not since stop. There doesn't seem to be an easy way to achieve the former.
- Largest time unit is `h`, see https://pkg.go.dev/time#ParseDuration.
- A better solution might be to redirect the webserver's log (for Caddy at least) to a real file in `/var/log` on the host where it could be properly handled by logrotate, but not sure how much effort that would be.
