### PR TITLE
Fix deprecation warning

### DIFF
--- a/ansible/playbook-setup-kiwi3.yml
+++ b/ansible/playbook-setup-kiwi3.yml
@@ -221,7 +221,7 @@
       name: "{{ item }}"
       state: >-
         {{
-          vars[item+'_cfg'].changed | default(false)
+          lookup('vars', item+'_cfg').changed | default(false)
           | ternary('reloaded', 'started')
         }}
       enabled: yes

--- a/ansible/playbook-setup-quince.yml
+++ b/ansible/playbook-setup-quince.yml
@@ -139,7 +139,7 @@
       name: "{{ item }}"
       state: >-
         {{
-          vars[item+'_cfg'].changed | default(false)
+          lookup('vars', item+'_cfg').changed | default(false)
           | ternary('reloaded', 'started')
         }}
       enabled: yes


### PR DESCRIPTION
`[DEPRECATION WARNING]: The internal "vars" dictionary is deprecated. This feature will be removed from ansible-core version 2.24.`

Fixes issue #19.
