### PR TITLE
kiwi3: Prune Docker build cache

### DIFF
--- a/ansible/playbook-setup-kiwi3.yml
+++ b/ansible/playbook-setup-kiwi3.yml
@@ -275,3 +275,5 @@
         until: 1440h
       images: true
       volumes: true
+      builder_cache: true
+      builder_cache_keep_storage: 8G


### PR DESCRIPTION
The build cache had grown to 24 GiB (as shown by `docker system df`), and after `docker system prune -a` went down to 4 GiB.

Not entirely sure what to use as value for the `builder_cache_keep_storage` parameter. Let's start with `8G`; we can always increase it if rebuilds would become slower.
